### PR TITLE
Use correct mime type

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -133,7 +133,7 @@ var zipcelx = (config) => {
   const worksheet = generateXMLWorksheet(config.sheet.data);
   xl.file('worksheets/sheet1.xml', worksheet);
 
-  return zip.generateAsync({ type: 'blob' })
+  return zip.generateAsync({ type: 'blob', mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
     .then((blob) => {
       FileSaver.saveAs(blob, `${config.filename}.xlsx`);
     });


### PR DESCRIPTION
With this fix the browser will understand that the file is an Excel file, and can suggest a proper app to open it with.